### PR TITLE
Potential fix for code scanning alert no. 10: Unused variable, import, function or class

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trophy, BarChart3 } from 'lucide-react';
+import { BarChart3 } from 'lucide-react';
 import { cn, formatCompactNumber } from '../utils';
 import { 
   Chart as ChartJS, 


### PR DESCRIPTION
Potential fix for [https://github.com/toxicbishop/Student-Stock-Market-Analysis/security/code-scanning/10](https://github.com/toxicbishop/Student-Stock-Market-Analysis/security/code-scanning/10)

In general, the way to fix an unused import is to either remove it if it’s not needed, or start using it if it was intended to be used. To avoid changing existing functionality, we should not introduce new usages of `Trophy` just to justify its presence; instead, we should remove only the unused symbol from the import list and leave the rest untouched.

In this case, the best fix is to edit `src/components/Leaderboard.tsx` so that only `BarChart3` is imported from `lucide-react`. Concretely, on line 2 we should change `import { Trophy, BarChart3 } from 'lucide-react';` to `import { BarChart3 } from 'lucide-react';`. No other parts of the file need to change, since `Trophy` is not referenced anywhere else and removing it will not affect runtime behavior.

No new methods, imports, or definitions are needed to implement the change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
